### PR TITLE
Update JuicyPixels-repa.cabal

### DIFF
--- a/JuicyPixels-repa.cabal
+++ b/JuicyPixels-repa.cabal
@@ -1,5 +1,5 @@
 Name:                JuicyPixels-repa
-Version:             0.4
+Version:             0.4.1
 Synopsis:            Convenience functions to obtain array representations of images.
 Description:         This wraps the Juicy.Pixels library to convert into 'Repa' and 
                      'Data.Vector.Storable' formats.
@@ -19,7 +19,7 @@ Cabal-version:       >=1.6
 Library
   Exposed-modules:     Codec.Picture.Repa
   Build-depends:       base >= 4.0 && < 5, repa >= 3.0 && < 3.3
-                    , JuicyPixels >= 1.1 && < 1.4
+                    , JuicyPixels >= 1.1 && < 2.1
                     , vector >= 0.9 && < 0.10
                     , bytestring >= 0.9 && < 0.10
   -- Other-modules:       


### PR DESCRIPTION
Bumping JuicyPixels version range, as the Image type didn't change between release, it's safe to extend the version range
